### PR TITLE
feat: allowing parallel cypress processes in same job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,5 +22,18 @@ jobs:
       - name: Install Dependencies
         run: yarn install --frozen-lockfile --prefer-offline
 
+      # Turborepo attempts to run as many tasks as possible over all available CPU's.
+      # This causes problems when multiple Cypress tasks run concurrently as each tries
+      # to instantiate xvfb and only one can do so. The solution is to start the process
+      # beforehand and set the DISPLAY environment variable which stops Cypress from
+      # attempting to instantiate xvfb itself. Multiple processes of Cypress can share
+      # the same instance of xvfb.
       - name: Run tests
-        run: yarn run test --concurrency=1
+        run: |
+          Xvfb :99 & export DISPLAY=:99
+          echo ---
+          npx cypress info
+          echo ---
+          node -p 'os.cpus()'
+          echo ---
+          yarn run test

--- a/packages/tds-core/package.json
+++ b/packages/tds-core/package.json
@@ -23,7 +23,7 @@
     "clean": "rm -rf .turbo && rm -rf cypress/screenshots && rm -rf cypress/videos && rm -rf node_modules && rm -rf dist",
     "dev": "tsup src/index.tsx --format esm,cjs --watch --dts --external react",
     "lint": "TIMING=1 eslint src/**/*.ts* --fix",
-    "test": "cypress run --component",
+    "test": "cypress run --component --browser=chrome",
     "test:gui": "cypress open --component --browser chrome",
     "types:check": "tsc --noEmit"
   },

--- a/packages/tds-deprecated/package.json
+++ b/packages/tds-deprecated/package.json
@@ -23,7 +23,7 @@
     "clean": "rm -rf .turbo && rm -rf cypress/screenshots && rm -rf cypress/videos && rm -rf node_modules && rm -rf dist",
     "dev": "tsup src/index.tsx --format esm,cjs --watch --dts --external react",
     "lint": "TIMING=1 eslint src/**/*.ts* --fix",
-    "test": "cypress run --component",
+    "test": "cypress run --component --browser=chrome",
     "test:gui": "cypress open --component --browser chrome",
     "types:check": "tsc --noEmit"
   },


### PR DESCRIPTION
- Making component tests run in chrome (which is an available browser within the `ubuntu-latest` machine).
- Fixing issue with cypress tasks not running in parallel due to each one attempting to instantiate `xvfb`.
- Adding debug information which outputs the number of CPU cores available to the job and the memory available.

_(Note: Running these in parallel on the same job will have limitations. In reality for a bigger suite or for a production grade solution, it would be more advisable to spin up multiple jobs; one per cypress instance required. That kind of parallelism will be faster in the long run.)_