### PR TITLE
fix: adding multiple tsconfig files

### DIFF
--- a/.changeset/tricky-owls-explain.md
+++ b/.changeset/tricky-owls-explain.md
@@ -1,0 +1,5 @@
+---
+"@anthonyhastings/tds-utils": patch
+---
+
+Adding second tsconfig file explicit for builds

--- a/packages/tds-utils/package.json
+++ b/packages/tds-utils/package.json
@@ -24,7 +24,7 @@
     "dist/**"
   ],
   "scripts": {
-    "build": "vite build && tsc --project tsconfig.json --declaration --emitDeclarationOnly --outDir dist",
+    "build": "vite build && tsc --project tsconfig.build.json --declaration --emitDeclarationOnly --outDir dist",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "lint": "TIMING=1 eslint src/**/*.ts* --fix",
     "test": "jest",

--- a/packages/tds-utils/tsconfig.build.json
+++ b/packages/tds-utils/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "src/**/*.spec.ts", "src/**/*.spec.tsx"]
+}

--- a/packages/tds-utils/tsconfig.json
+++ b/packages/tds-utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "config-tsconfig/react-library.json",
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["node_modules", "src/**/*.spec.ts", "src/**/*.spec.tsx"]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
While `include` and `exclude` are supposed to only affect what files get built / emitted, it seems to be affecting what will get type checked. In light of this, the main configuration file will now include all source and test files so the IDE and the CLI commands will test everything correctly. When it comes to building the package, we add a second configuration file that explicitly ignores test files.