### PR TITLE
fix(tds-deprecated): adding export for src folder/file

### DIFF
--- a/packages/tds-deprecated/package.json
+++ b/packages/tds-deprecated/package.json
@@ -16,8 +16,11 @@
   "type": "module",
   "sideEffects": false,
   "exports": {
-    "require": "./dist/tds-deprecated.cjs",
-    "import": "./dist/tds-deprecated.js"
+    "./src": "./src/index.tsx",
+    ".": {
+      "require": "./dist/tds-deprecated.cjs",
+      "import": "./dist/tds-deprecated.js"
+    }
   },
   "license": "MIT",
   "files": [


### PR DESCRIPTION
When trying to build the storybook in `apps/docs` it resulted in a failure. The reason why is because one of the stories (`apps/docs/stories/anchor.stories.mdx`) attempted to load the path `import { Anchor } from '@anthonyhastings/tds-deprecated/src';`.

The issue is that, whenever `exports` was added into the package file of the module in question, it mass grabbed all usage of `require` and `import` and pointed them to files in the `dist/` folder. Whenever the storybook story attempted to access the `src/` directory within the package, it failed because it wasn't "exported" from the module. Adding `exports` into the package file of a module makes all imports of that package fully enforced; anything not explicitly exported cannot be imported.

This PR adds a dedicated path in for the src directory, pointing any imports of it at `src/index.tsx`. Any other imports or requires from this module load the respective dist file.

More Information:
 - [Conditional Exports](https://nodejs.org/api/packages.html#subpath-exports:~:text=features/x.js-,Conditional%20exports,-%23)