### PR TITLE
fix: ensuring git hooks are installed as part of lifecycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "clean": "turbo run clean && rm -rf node_modules",
     "changeset": "changeset add",
     "version-packages": "changeset version",
+    "prepare": "husky install",
     "prerelease": "yarn run build",
     "release": "changeset publish",
     "test": "turbo run test",


### PR DESCRIPTION
It occurred to me that `commitlint` wasn't running when I was committing to the repository. It turns out that the husky git hooks weren't installed. That appears to be because I was missing the `prepare` lifecycle script which runs after doing an `npm install`.