### PR TITLE
fix: fixing conventional commit messages when releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
         with:
           publish: yarn run release
           version: yarn run version-packages
+          commit: 'chore: release package(s)'
+          title: 'chore: release package(s)'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Adding conventional commit message so that changesets action when committing won't fail on `commitlint`.