### PR TITLE
Turborepo: Only testing affected packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
 
       - name: Set Node.js Version
         uses: actions/setup-node@v3
@@ -34,6 +36,7 @@ jobs:
           yarn install --frozen-lockfile --prefer-offline
           yarn --silent cypress info
           yarn --silent cypress cache list
+          node -p 'os.cpus()'
 
       # Turborepo attempts to run as many tasks as possible over all available CPU's.
       # This causes problems when multiple Cypress tasks run concurrently as each tries
@@ -41,12 +44,18 @@ jobs:
       # beforehand and set the DISPLAY environment variable which stops Cypress from
       # attempting to instantiate xvfb itself. Multiple processes of Cypress can share
       # the same instance of xvfb.
+      #
+      # In order to be efficient we can ask Turborepo to only run commands against the
+      # workspaces that have files changed. Other workspaces will be ignored. In order
+      # to achieve this, normally the syntax would be:
+      #
+      # yarn run test --filter ...\[origin/main...origin/testing-packages\]
+      #
+      # However Github Actions checks out a repo in a detached head with no knowledge of
+      # any other branch. It has no concept of the trunk branch. To get around this, we
+      # update the `actions/checkout@v3` to fetch further back so we can use HEAD^1 to
+      # reference the commit we've branched off of (99% of time that'll be the trunk).
       - name: Run Package(s) Tests
         run: |
           Xvfb :99 & export DISPLAY=:99
-          echo ---
-          npx cypress info
-          echo ---
-          node -p 'os.cpus()'
-          echo ---
-          yarn run test
+          yarn run test --filter ...\[HEAD^1\]

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
     "syncpack": "^9.7.4",
-    "turbo": "^1.8.1"
+    "turbo": "^1.8.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12637,47 +12637,47 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-turbo-darwin-64@1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-1.8.1.tgz#3e3e64fe7ea7d0bcd192e2e608274a06c662d1d5"
-  integrity sha512-H7pxGF/vsYG7kbY+vB8h+3r8VXn2L6hhYQi0XWA+EjZ1e2zu7+TzEMRWFYmvJPx8TRo5cV5txtg0I22/Y7bxUA==
+turbo-darwin-64@1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-1.8.2.tgz#14c52e97d128c63fd3c7b2f15963123f02b9aa0e"
+  integrity sha512-j77U0uOeppENexFsIvvzExADSqMBEeCHnm+6LSNQfaajHSrbUVSTsuD6ZMYHamT6bslc+ZZm21jdecWkwZFBbw==
 
-turbo-darwin-arm64@1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-1.8.1.tgz#d855340af02a448c428881a65c2deef75108caff"
-  integrity sha512-zMcvplVGluR6v4oJXW7S1/R9QFsHdDkXMhPq8PIdvT3HwTb69ms0MNv7aKiQ0ZFy5D/eKCTyBRUFZvjorZmBqA==
+turbo-darwin-arm64@1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-1.8.2.tgz#ae5efdb89cbdd667feacd3fe8e9c8110691a4d95"
+  integrity sha512-1NoAvjlwt2wycsAFJouauy9epn9DptSMy6BoGqxJVc4jiibsLepp9qYc4f1/ln0zjd3FR1IvhGOiBfdpqMN7hg==
 
-turbo-linux-64@1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-1.8.1.tgz#9f1dac8c7f40d7ba43adf407ed59dc03f52c7601"
-  integrity sha512-eJNx8iWDn5Lt8d0221RFd6lBjViLiPCVWNFF5JtqOohgRYplvepY3y/THa1GivMxY4px6zjTiy2oPE/VscVP4w==
+turbo-linux-64@1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-1.8.2.tgz#02442a48104db83c1e53409c85744fdeacbded56"
+  integrity sha512-TcT3CRYnBYA46kLGGbGC2jDyCEAvMgVpUdpIZGTmod48EKpZaEfVgTkpa4GJde8W68yRFogPZjPVL3yJHFpXSA==
 
-turbo-linux-arm64@1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-1.8.1.tgz#4ab5ca579b16b501ad98f0ed1ff22bcc13ffd1d7"
-  integrity sha512-hFZkm8tq9kLE8tdbOzD6EbNzftdzMR4JEuuoKC6AbTzx1ZsWRvXJ/BGTeSH9/dYYm/wfuIEUiOP7HeXWiZRx7g==
+turbo-linux-arm64@1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-1.8.2.tgz#890ad0691671cb252e756dcd56295895f61d369a"
+  integrity sha512-Mb9+KBy4YJzPMZ6WGoMzMVZ6EtueCSvOvgmNpVFgkwbtabfBuaBOvN+irtg4RRSWvJQTDTziLABieocEEXZImQ==
 
-turbo-windows-64@1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-1.8.1.tgz#4bc3648ff387ec4dfc781c4ec9213da320cac563"
-  integrity sha512-o3oDg0lTYZl5KZD3Mi753On2vQT51unIiungoUmHDCeDH5JXfWPFu+6p+GAoIyRwQkZPvaEzMLuUtRgklKcBJw==
+turbo-windows-64@1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-1.8.2.tgz#a57b902cdccdb69d1efa18772bee9e277e079583"
+  integrity sha512-/+R5ikRrw2w2w38JtNPubGLIQHgUC70m783DI9aPgaM5c8P5D/Y0k6HgjuC/uXgiaz2h3R7p7YWlr+2/E0bqyA==
 
-turbo-windows-arm64@1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/turbo-windows-arm64/-/turbo-windows-arm64-1.8.1.tgz#9b4487ec4382da8f95e2be361fbbaff9d1fb8901"
-  integrity sha512-NDYr2Mra21KOdl18BhMRoH2jQmlu+oqkpqRd+cGB8+c5P0B6LDVCM83cfcXQ+PNqX9S3Y1eZDRENZJx9I03sSw==
+turbo-windows-arm64@1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/turbo-windows-arm64/-/turbo-windows-arm64-1.8.2.tgz#0f976a2c6b8a46447fc277d5a9f7d8615792bdde"
+  integrity sha512-s07viz5nXSx4kyiksuPM4FGLRkoaGMaw0BpwFjdRQsl1p+WclUN1IPdokVPKOmFpu5pNCVYlG/raP/mXAEzDCg==
 
-turbo@^1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/turbo/-/turbo-1.8.1.tgz#f53c0dce2d69f75dc64dfd40a1d8faee2330744b"
-  integrity sha512-g8RltmG5zd0nYbKpkBQwnTSXTWUiup9+yileQ1TETNzpjxI3TL5k7kt2WkgUHEqR947IPUV+ckIduZHVITJmIQ==
+turbo@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/turbo/-/turbo-1.8.2.tgz#869e674a524cde4f449ae4458f4651818e2ffe00"
+  integrity sha512-G/uJx6bZK5RwTWHsRN/MP0MvXFznmCaL3MQXdSf+OG/q0o8GE7+yivyyWEplWI1Asc8AEN909A/wlIkoz2FKTg==
   optionalDependencies:
-    turbo-darwin-64 "1.8.1"
-    turbo-darwin-arm64 "1.8.1"
-    turbo-linux-64 "1.8.1"
-    turbo-linux-arm64 "1.8.1"
-    turbo-windows-64 "1.8.1"
-    turbo-windows-arm64 "1.8.1"
+    turbo-darwin-64 "1.8.2"
+    turbo-darwin-arm64 "1.8.2"
+    turbo-linux-64 "1.8.2"
+    turbo-linux-arm64 "1.8.2"
+    turbo-windows-64 "1.8.2"
+    turbo-windows-arm64 "1.8.2"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
Turborepo is able to examine a `git diff` and translate the changed files back to the workspaces they belong to, as well as the dependents of those workspaces. This helps to ensure we test only what is affected by our change.

More Information:
- [Filtering](https://turbo.build/repo/docs/core-concepts/monorepos/filtering#include-dependents-of-matched-workspaces)