### PR TITLE
fix: ensuring TypeScript expects ESM for module resolution

### DIFF
--- a/.changeset/old-cheetahs-applaud.md
+++ b/.changeset/old-cheetahs-applaud.md
@@ -1,0 +1,7 @@
+---
+"@anthonyhastings/tds-core": patch
+"@anthonyhastings/tds-deprecated": patch
+"@anthonyhastings/tds-utils": patch
+---
+
+fix: ensuring TypeScript expects ESM for module resolution

--- a/packages/config-tsconfig/base.json
+++ b/packages/config-tsconfig/base.json
@@ -9,7 +9,7 @@
     "forceConsistentCasingInFileNames": true,
     "inlineSources": false,
     "isolatedModules": true,
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "preserveWatchOutput": true,

--- a/packages/config-tsconfig/package.json
+++ b/packages/config-tsconfig/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "license": "MIT",
-  "main": "index.js",
   "files": [
     "base.json",
     "node16.json",

--- a/packages/tds-core/cypress/support/component.ts
+++ b/packages/tds-core/cypress/support/component.ts
@@ -14,7 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands';
+import './commands.js';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/packages/tds-core/package.json
+++ b/packages/tds-core/package.json
@@ -11,18 +11,19 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },
+  "exports": {
+    "./src": "./src/index.ts",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/tds-core.cjs",
+      "import": "./dist/tds-core.js"
+    }
+  },
   "main": "./dist/tds-core.cjs",
   "module": "./dist/tds-core.js",
   "types": "./dist/index.d.ts",
   "type": "module",
   "sideEffects": false,
-  "exports": {
-    "./src": "./src/index.ts",
-    ".": {
-      "require": "./dist/tds-core.cjs",
-      "import": "./dist/tds-core.js"
-    }
-  },
   "license": "MIT",
   "files": [
     "dist/**"

--- a/packages/tds-core/src/Button.cy.tsx
+++ b/packages/tds-core/src/Button.cy.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from './Button';
+import { Button } from './Button.js';
 
 it('renders with supplied children', () => {
   const onClickStub = cy.stub().as('onClickStub');

--- a/packages/tds-core/src/Heading.cy.tsx
+++ b/packages/tds-core/src/Heading.cy.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Heading } from './Heading';
+import { Heading } from './Heading.js';
 
 it('renders with supplied children', () => {
   cy.mount(<Heading>Why change?</Heading>);

--- a/packages/tds-core/src/index.ts
+++ b/packages/tds-core/src/index.ts
@@ -1,2 +1,2 @@
-export { Button, type ButtonProps } from './Button';
-export { Heading, type HeadingProps } from './Heading';
+export { Button, type ButtonProps } from './Button.js';
+export { Heading, type HeadingProps } from './Heading.js';

--- a/packages/tds-deprecated/cypress/support/component.ts
+++ b/packages/tds-deprecated/cypress/support/component.ts
@@ -14,7 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands';
+import './commands.js';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/packages/tds-deprecated/package.json
+++ b/packages/tds-deprecated/package.json
@@ -11,18 +11,19 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },
+  "exports": {
+    "./src": "./src/index.ts",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/tds-deprecated.cjs",
+      "import": "./dist/tds-deprecated.js"
+    }
+  },
   "main": "./dist/tds-deprecated.cjs",
   "module": "./dist/tds-deprecated.js",
   "types": "./dist/index.d.ts",
   "type": "module",
   "sideEffects": false,
-  "exports": {
-    "./src": "./src/index.ts",
-    ".": {
-      "require": "./dist/tds-deprecated.cjs",
-      "import": "./dist/tds-deprecated.js"
-    }
-  },
   "license": "MIT",
   "files": [
     "dist/**"

--- a/packages/tds-deprecated/src/Anchor.cy.tsx
+++ b/packages/tds-deprecated/src/Anchor.cy.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Anchor } from './Anchor';
+import { Anchor } from './Anchor.js';
 
 it('renders with supplied children', () => {
   cy.mount(<Anchor>Find out more</Anchor>);

--- a/packages/tds-deprecated/src/index.ts
+++ b/packages/tds-deprecated/src/index.ts
@@ -1,1 +1,1 @@
-export { Anchor, type AnchorProps } from './Anchor';
+export { Anchor, type AnchorProps } from './Anchor.js';

--- a/packages/tds-utils/jest.config.ts
+++ b/packages/tds-utils/jest.config.ts
@@ -4,6 +4,15 @@ const configuration: Config.InitialOptions = {
   collectCoverage: true,
   preset: 'ts-jest',
   testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
+  },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
 };
 
 export default configuration;

--- a/packages/tds-utils/src/index.ts
+++ b/packages/tds-utils/src/index.ts
@@ -1,2 +1,2 @@
-export { useIsomorphicLayoutEffect } from './utils/useIsomorphicLayoutEffect';
-export { usePrevious } from './utils/usePrevious';
+export { useIsomorphicLayoutEffect } from './utils/useIsomorphicLayoutEffect.js';
+export { usePrevious } from './utils/usePrevious.js';

--- a/packages/tds-utils/src/strings.ts
+++ b/packages/tds-utils/src/strings.ts
@@ -1,2 +1,2 @@
-export { capitalize } from './utils/capitalize';
-export { toSlug } from './utils/toSlug';
+export { capitalize } from './utils/capitalize.js';
+export { toSlug } from './utils/toSlug.js';

--- a/packages/tds-utils/src/utils/capitalize.spec.ts
+++ b/packages/tds-utils/src/utils/capitalize.spec.ts
@@ -1,4 +1,4 @@
-import { capitalize } from './capitalize';
+import { capitalize } from './capitalize.js';
 
 describe('#capitalize', () => {
   test.each([

--- a/packages/tds-utils/src/utils/toSlug.spec.ts
+++ b/packages/tds-utils/src/utils/toSlug.spec.ts
@@ -1,4 +1,4 @@
-import { toSlug } from './toSlug';
+import { toSlug } from './toSlug.js';
 
 describe('#toSlug', () => {
   test.each([

--- a/packages/tds-utils/src/utils/usePrevious.spec.ts
+++ b/packages/tds-utils/src/utils/usePrevious.spec.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { usePrevious } from './usePrevious';
+import { usePrevious } from './usePrevious.js';
 
 describe('#usePrevious', () => {
   it('1 + 1 = 2', () => {


### PR DESCRIPTION
| IntelliSense (Before) | IntelliSense (After) |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/167421/221413848-a79d6332-2018-4517-a0e9-53e8a411c027.png) | ![after](https://user-images.githubusercontent.com/167421/221413860-3ca24976-7372-470b-9e94-e393a415ab56.png) |

<table>
<thead>
<tr>
<th>

`packages/tds-utils/dist/index.d.ts` (Before)

</th>
<th>

`packages/tds-utils/dist/index.d.ts` (After)

</th>
</tr>
</thead>
<tbody>
<tr>
<td>

```ts
export { useIsomorphicLayoutEffect } from './utils/useIsomorphicLayoutEffect';
export { usePrevious } from './utils/usePrevious';
```

</td>
<td>

```ts
export { useIsomorphicLayoutEffect } from './utils/useIsomorphicLayoutEffect.js';
export { usePrevious } from './utils/usePrevious.js';
```

</td>
</tr>
</tbody>
</table>

**Issue:**
IntelliSense on packages using `exports` with nested `types` weren't working correctly. This is because the packages were heralding themselves as ESM packages (via `"type": "module"` within their package files) but the type declaration files that had `export` statements weren't adding file extensions to their paths (which is a requirement in ESM module resolution).

**Fixes:**
- Updating base TS Config file to set `moduleResolution` to `nodenext` which enables resolving ESM modules from TypeScript 4.7 onwards.
- Adding file extensions to import statements to adhere with ESM syntax.
- Updating `jest` / `ts-jest` configuration within `tds-utils` to enable ESM.
- Adding `types` statement into `exports` field of `tds-utils` and `tds-deprecated`.
- Cutting new patch versions of all three packages to supply fixes for ESM type definition files.
- (Unrelated) Removing unused / inaccurate `main` declaration from `common-tsconfig`.

_(Note: `types` **must** be the first key/value pair within export declarations of the package file)_

## Further Information
- [TypeScript - ECMAScript Modules in Node.js](https://www.typescriptlang.org/docs/handbook/esm-node.html)
- [Module Resolution strategies](https://www.typescriptlang.org/docs/handbook/module-resolution.html#module-resolution-strategies)