### PR TITLE
fix: snapshot release diffs

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -29,9 +29,9 @@ jobs:
 
       - name: Create Snapshot Release
         run: |
+          yarn run version-packages --snapshot "${{ github.ref_name }}"
           echo '---'
           echo 'Detected Changes:'
           git diff
           echo '---'
-          yarn run version-packages --snapshot "${{ github.ref_name }}"
           yarn run release --tag "${{ github.ref_name }}" --no-git-tag


### PR DESCRIPTION
Diffing should happen **after** `changeset version` where it updates changelogs and package files, but **before** publishing to registry.